### PR TITLE
Revert paper-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
           <groupId>io.papermc.paper</groupId>
           <artifactId>paper-api</artifactId>
-          <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>${spigot.version}</version>
           <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This reverts paper-api dependency back to ${spigot-version}